### PR TITLE
make Kafka integration optional: update `KafkaMessageService` and `Me…

### DIFF
--- a/iam_Service/.gitignore
+++ b/iam_Service/.gitignore
@@ -31,3 +31,8 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Secrets (never commit) ###
+.env
+application-secret.properties
+**/application-secret.properties

--- a/iam_Service/pom.xml
+++ b/iam_Service/pom.xml
@@ -28,7 +28,20 @@
         <springdoc.version>2.8.3</springdoc.version>
         <postgresql.version>42.7.8</postgresql.version>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <spring-cloud.version>2023.0.1</spring-cloud.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Spring Boot Starters -->
@@ -130,6 +143,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/iam_Service/src/main/java/com/post_hub/iam_Service/config/SecurityConfig.java
+++ b/iam_Service/src/main/java/com/post_hub/iam_Service/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/auth/**").permitAll()
-                        .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/v3/api-docs", "/swagger-resources/**", "/webjars/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/v3/api-docs", "/swagger-resources/**", "/webjars/**", "/actuator/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/users/create").hasAnyAuthority(adminAccessSecurityRoles())
                         .anyRequest().authenticated()
                 )

--- a/iam_Service/src/main/java/com/post_hub/iam_Service/kafka/MessageProducer.java
+++ b/iam_Service/src/main/java/com/post_hub/iam_Service/kafka/MessageProducer.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
@@ -19,6 +20,7 @@ import org.springframework.validation.annotation.Validated;
 @Component
 @Validated
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "kafka.enabled", havingValue = "true")
 public class MessageProducer {
 
     private final ObjectMapper objectMapper;

--- a/iam_Service/src/main/java/com/post_hub/iam_Service/kafka/service/KafkaMessageService.java
+++ b/iam_Service/src/main/java/com/post_hub/iam_Service/kafka/service/KafkaMessageService.java
@@ -7,10 +7,12 @@ import com.post_hub.iam_Service.model.constants.ApiKafkaMessage;
 import com.post_hub.iam_Service.kafka.MessageProducer;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "kafka.enabled", havingValue = "true")
 public class KafkaMessageService {
     private final MessageProducer messageProducer;
 

--- a/iam_Service/src/main/java/com/post_hub/iam_Service/service/impl/UserServiceImpl.java
+++ b/iam_Service/src/main/java/com/post_hub/iam_Service/service/impl/UserServiceImpl.java
@@ -35,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -46,7 +47,7 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
     private final RoleRepository roleRepository;
     private final AccessValidator accessValidator;
-    private final KafkaMessageService kafkaMessageService;
+    private final Optional<KafkaMessageService> kafkaMessageService;
     @Override
     @Transactional(readOnly = true)
     public IamResponse<UserDTO> getById(@NonNull Integer userId) {
@@ -78,7 +79,7 @@ public class UserServiceImpl implements UserService {
         roles.add(userRole);
         user.setRoles(roles);
         User savedUser = userRepository.save(user);
-        kafkaMessageService.sendUserCreatedMessage(savedUser.getId(), savedUser.getUsername());
+        kafkaMessageService.ifPresent(service -> service.sendUserCreatedMessage(savedUser.getId(), savedUser.getUsername()));
         return IamResponse.createSuccessful(userMapper.toDto(savedUser));
     }
 

--- a/iam_Service/src/main/resources/application-local-idea.properties
+++ b/iam_Service/src/main/resources/application-local-idea.properties
@@ -4,8 +4,8 @@ server.servlet.context-path=/
 
 server.port=8189
 spring.datasource.url=jdbc:postgresql://host.docker.internal:5432/post_hub_local
-spring.datasource.username=postgres
-spring.datasource.password=postgresql
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.username=${DB_USERNAME:postgres}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.jpa.properties.hibernate.default_schema=v1_iam_service
@@ -57,6 +57,9 @@ spring.kafka.retry.topic.enabled=true
 swagger.servers.first=http://localhost:8189
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.api-docs.path=/v3/api-docs
+
+
+
 
 logging.level.com.post_hub.iam_Service = TRACE
 logging.level.org.springframework.web=DEBUG

--- a/iam_Service/src/test/java/com/post_hub/iam_Service/service/CommentServiceTest.java
+++ b/iam_Service/src/test/java/com/post_hub/iam_Service/service/CommentServiceTest.java
@@ -43,10 +43,16 @@ class CommentServiceTest {
 
     @Mock
     private APIUtils apiUtils;
+
     @Mock
     private KafkaMessageService kafkaMessageService;
 
-    @InjectMocks
+    @Mock
+    private com.post_hub.iam_Service.mapper.PostMapper postMapper;
+
+    @Mock
+    private com.post_hub.iam_Service.security.validation.AccessValidator accessValidator;
+
     private CommentServiceImpl commentService;
 
     private Comment tesComment;
@@ -56,6 +62,17 @@ class CommentServiceTest {
 
     @BeforeEach
     void setUp() {
+        commentService = new CommentServiceImpl(
+                commentRepository,
+                commentMapper,
+                apiUtils,
+                userRepository,
+                postRepository,
+                postMapper,
+                accessValidator,
+                Optional.of(kafkaMessageService)
+        );
+
         testUser = new User();
         testUser.setId(1);
         testUser.setUsername("TestUser");

--- a/iam_Service/src/test/java/com/post_hub/iam_Service/service/PostServiceTest.java
+++ b/iam_Service/src/test/java/com/post_hub/iam_Service/service/PostServiceTest.java
@@ -39,10 +39,13 @@ class PostServiceTest {
 
     @Mock
     private APIUtils apiUtils;
+
     @Mock
     private KafkaMessageService kafkaMessageService;
 
-    @InjectMocks
+    @Mock
+    private com.post_hub.iam_Service.security.validation.AccessValidator accessValidator;
+
     private PostServiceImpl postService;
 
     private Post testPost;
@@ -51,6 +54,15 @@ class PostServiceTest {
 
     @BeforeEach
     void setUp() {
+        postService = new PostServiceImpl(
+                postRepository,
+                userRepository,
+                postMapper,
+                accessValidator,
+                apiUtils,
+                Optional.of(kafkaMessageService)
+        );
+
         testUser = new User();
         testUser.setId(1);
         testUser.setUsername("TestUser");

--- a/iam_Service/src/test/java/com/post_hub/iam_Service/service/UserServiceTest.java
+++ b/iam_Service/src/test/java/com/post_hub/iam_Service/service/UserServiceTest.java
@@ -59,7 +59,6 @@ class UserServiceTest {
     @Mock
     private AccessValidator accessValidator;
 
-    @InjectMocks
     private UserServiceImpl userService;
 
     private User testUser;
@@ -69,6 +68,15 @@ class UserServiceTest {
 
     @BeforeEach
     void setUp() {
+        userService = new UserServiceImpl(
+                userRepository,
+                userMapper,
+                passwordEncoder,
+                roleRepository,
+                accessValidator,
+                Optional.of(kafkaMessageService)
+        );
+
         userRole = new Role();
         userRole.setName(IamServiceUserRole.USER.getRole());
 

--- a/iam_Service/src/test/resources/application.properties
+++ b/iam_Service/src/test/resources/application.properties
@@ -1,23 +1,22 @@
-# Import secrets (optional - won't fail if file doesn't exist)
-spring.config.import=optional:classpath:application-secret.properties
-
 spring.application.name=iam_Service
 server.servlet.context-path=/
-
-
 server.port=8189
-spring.datasource.url=jdbc:postgresql://localhost:5432/post_hub_local
-spring.datasource.password=${DB_PASSWORD:}
-spring.datasource.username=${DB_USERNAME:postgres}
-spring.datasource.driver-class-name=org.postgresql.Driver
 
-spring.jpa.properties.hibernate.default_schema=v1_iam_service
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update
+# H2 Database for testing
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
 
-spring.flyway.enabled=true
-spring.flyway.locations=classpath:db/migration
-spring.flyway.schemas=v1_iam_service
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+
+# Disable Flyway for tests (H2 will use JPA schema generation)
+spring.flyway.enabled=false
+
+# Enable data.sql execution
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true
 
 end.point.posts=/posts
 end.point.id=/{id}
@@ -37,31 +36,16 @@ swagger.servers.first=http://localhost:8189
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.api-docs.path=/v3/api-docs
 
-# Kafka
-kafka.enabled=true
-spring.kafka.bootstrap-servers=localhost:9092
-spring.kafka.consumer.group-id=iam_service
+# Kafka - disabled for tests
+kafka.enabled=false
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
 
 additional.kafka.topic.iam.service.logs=iam_topic_for_demo
-
-spring.kafka.listener.ack-mode=manual
-
-spring.kafka.consumer.enable-auto-commit=false
-spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.consumer.auto-offset-reset=earliest
-
-spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
-spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
-spring.kafka.producer.compression-type=lz4
-spring.kafka.producer.batch-size=50000
-spring.kafka.retry.topic.enabled=true
 
 # JWT Configuration
 jwt.secret=7J9kL2nM5pQ8sT1vW4yZ7aC0dF3gI6jM9oR2uX5wA8cE1hK4mP7rU0xB3eG6iL9nQ2sV5yC8fJ1mO4rT7wZ0bD3gH6kN9pS2uW5xA8cF1eI4jM7oQ0sT3vY6zA9bE2gH5kL8nP1rU4wX7yB0dF3iJ6mN9pS2uV5xA8cE1gH4kL7nO0qT3vW6yZ9bD2eG5iJ8mP1rU4wX7zA0cF3hK6nO9qS2uV5xB8dG1eI4jL7mP0rT3wY6zA9cE2fH5kN8pS1uW4xA7bD0eG3iJ6mO9qT2vX5yB8cF1hK4nP7rU0sW3vZ6aD9eG2iL5jN8oQ1tV4wX7yB0cE3fH6kM9pS2uW5zA8bD1eG4iJ7mO0qT3vX6yA9cF2hK5nP8rU1sW4vZ7aD0eG3iL6jN9oQ2tV5xB8cE1fH4kM7pS0uW3yA6bD9eG2iJ5mO8qT1vX4wZ7aF0cH3kN6pR9sU2vY5xB8dE1gJ4mO7qT0uW3yA6cF9eH2kL5nP8rS1uV4xZ7aD0bG3iJ6mO9qT2vW5yA8cF1eH4kN7pR0sU3vX6zA9bD2eG5iL8mP1qT4wY7aE0cF3hK6nO9rS2uV5xZ8bD1eG4iJ7mP0qT3vW6yA9cF2hK5nO8pS1uV4xZ7aD0eG3iJ6mP9qT2vW5yB8cF1hK4nO7pS0rU3vX6zA9bD2eG5iJ8mP1qT4wY7aE0cH3kN6oR9sU2vX5yB8dF1gJ4mO7pT0uW3vZ6aD9eG2iL5jN8oQ1sV4xY7bC0eF3hK6mP9rU2tW5yA8cD1fH4kN7pS0uV3xZ6aE9bG2iJ5mO8qT1vW4yA7cF0dH3kN6pR9sU2vX5yB8eG1fJ4mO7qT0uW3vZ6aD9cF2hL5kN8pS1rU4xY7bD0eG3iJ6mO9qT2vW5yA8cF1hK4nP7rU0sV3xZ6aD9bE2gI5jM8oQ1tW4vY7zA0cF3hK6nO9pS2uV5xB8dG1eI4jL7mP0qT3wY6zA9cE2fH5kN8pS1uW4xA7bD0eG3iJ==
 jwt.expiration=103600000
 
 #Logging Level
-logging.level.com.post_hub.iam_Service = TRACE
-logging.level.org.springfraemwork.web=DEBUG
-logging.level.org.flywaydb=DEBUG
+logging.level.com.post_hub.iam_Service=DEBUG
+logging.level.org.springframework.web=DEBUG


### PR DESCRIPTION
…ssageProducer` with conditional beans based on `kafka.enabled` property; refactor services to use `Optional<KafkaMessageService>` to handle absence of Kafka; update tests and test application properties to disable Kafka during testing; secure secrets using placeholders in `application.properties` and support importing external secrets; add `application-secret.properties` to `.gitignore`; enhance `pom.xml` with dependencies for optional Kafka support and add spring-cloud BOM; update security config to allow actuator endpoints